### PR TITLE
enable different package support in workspaces

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -51,6 +51,20 @@ impl CargoBuild {
         }
     }
 
+    /// Build from `name` package in workspaces.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// escargot::CargoBuild::new()
+    ///     .package("escargot")
+    ///     .bin("bin_fixture")
+    ///     .exec()
+    ///     .unwrap();
+    /// ```
+    pub fn package<S: AsRef<ffi::OsStr>>(self, name: S) -> Self {
+        self.arg("--package").arg(name)
+    }
     /// Build only `name` binary.
     ///
     /// # Example


### PR DESCRIPTION
This option adds an ability to build and run targets from different member packages/crates in workspaces.

Workspaces contain several crates and it is a common situation when integration tests are located in a separate crate.