### PR TITLE
Fix CargoTest#exec

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -71,7 +71,7 @@ impl CargoTest {
     /// Run the build artifact.
     pub fn command(&self) -> process::Command {
         let mut cmd = process::Command::new(self.path());
-        cmd.arg("-Z unstable-options").arg("--format json");
+        cmd.arg("-Z").arg("unstable-options").arg("--format=json");
         cmd
     }
 


### PR DESCRIPTION
Otherwise you get this error:

```rust
[src/runspec.rs:117] res.command() = "/usr/home/andoriyu/Dev/suity/target/debug/not_really_a_test-3fff1f85edaa85b1" "-Z unstable-options" "--format json"
[src/runspec.rs:121] msg = Err(
    CargoError {
        kind: CommandFailed,
        context: Some(
            "error: Unrecognized option: \'format json\'\n"
        ),
        cause: None
    }
)
```