### PR TITLE
Fix a typo in CargoBuild.features()

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -217,7 +217,7 @@ impl CargoBuild {
 
     /// Space-separated list of features to activate
     pub fn features<S: AsRef<ffi::OsStr>>(self, features: S) -> Self {
-        self.arg("-features").arg(features)
+        self.arg("--features").arg(features)
     }
 
     /// Manually pass an argument that is unsupported.


### PR DESCRIPTION
A missing `-` is causing `CargoBuild.features()` to fail because cargo doesn't correctly recognize the option `--features`