### PR TITLE
Add public context getter to CargoError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,11 @@ impl CargoError {
     pub fn kind(&self) -> ErrorKind {
         self.kind
     }
+    
+    /// The full context of the error if set.
+    pub fn context(&self) -> Option<String> {
+        self.context
+    }
 }
 
 impl Error for CargoError {


### PR DESCRIPTION
Currently the only way to get the context is by printing the whole message and extracting it.