### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -69,10 +69,6 @@ impl CargoError {
 }
 
 impl Error for CargoError {
-    fn description(&self) -> &str {
-        "Cargo command failed."
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         self.cause.as_ref().map(|c| {
             let c: &dyn Error = c.as_ref();


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes an implementation of `description` in `impl Error`

Related PR: https://github.com/rust-lang/rust/pull/66919