### PR TITLE
Add `minimal_versions` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,31 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --workspace --all-features --all-targets -- -D warnings
+  minimal_versions:
+    name: Minimal versions
+    needs: smoke
+    strategy:
+      matrix:
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+        rust: [ "1.54.0" ] # MSRV
+    continue-on-error: ${{ matrix.rust != 'stable' }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+         profile: minimal
+         toolchain: nightly
+      - uses: actions-rs/toolchain@v1
+        with:
+         profile: minimal
+         toolchain: ${{ matrix.rust }}
+         override: true
+      - name: Downgrade crates to minimal supported versions
+        run: cargo +nightly update -Z minimal-versions
+      - uses: Swatinem/rust-cache@v1
+      - name: Default features
+        run: cargo test --workspace
+      - name: No-default features
+        run: cargo test --workspace --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ pre-release-replacements = [
 ]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.113", features = ["derive"] }
 serde_json = "1.0"
 once_cell = "1.2.0"
-log = "0.4"
+log = "0.4.4"
 
 [dev-dependencies]
 assert_fs = "1.0"


### PR DESCRIPTION
Revealed from https://github.com/clap-rs/clap/pull/3172

Actual minimal versions of `log` is `0.4.4`, not `0.4` and `1.0.113` for `serde`.  
To avoid similar issues, I've also added minimal_versions CI job, which downgrades all crates to minimal compatible versions and runs tests on them. Although it's nightly feature for cargo, we use it throughout multiple projects and never had any issues with it.