### PR TITLE
fix: get Command from Cargo and CargoBuild

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -59,6 +59,11 @@ impl CargoBuild {
         }
     }
 
+    /// Return the underlying [`process::Command`]
+    pub fn into_command(self) -> process::Command {
+        self.cmd
+    }
+
     /// Build from `name` package in workspaces.
     ///
     /// # Example

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -51,6 +51,11 @@ impl Cargo {
         self.cmd.arg(name).arg("--message-format=json");
         CargoBuild::with_command(self.cmd)
     }
+
+    /// Return the underlying [`process::Command`]
+    pub fn into_command(self) -> process::Command {
+        self.cmd
+    }
 }
 
 impl Default for Cargo {


### PR DESCRIPTION
Add `into_std_cmd` methods for `Cargo` and `CargoBuild`.

This closes #77