### PR TITLE
fix(format): expose the build success flag

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -33,12 +33,15 @@ pub enum Message<'a> {
     Unknown,
 }
 
-/// Build completed, all further output should not be parsed
+/// Build completed, all further output should not be parsed.
+///
+/// See <https://doc.rust-lang.org/cargo/reference/external-tools.html#build-finished>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "strict_unstable", serde(deny_unknown_fields))]
 #[non_exhaustive]
 pub struct BuildFinished {
-    success: bool,
+    /// Whether or not the build finished successfully.
+    pub success: bool,
 }
 
 /// A compiler-generated file.


### PR DESCRIPTION
This change exposes the build success flag in the `BuildFinished` struct since it’s hard for an API consumer to deduce this information otherwise.